### PR TITLE
Place the diplo icons back where they were

### DIFF
--- a/CTR/interface/menubar.gui
+++ b/CTR/interface/menubar.gui
@@ -86,7 +86,7 @@ guiTypes = {
 
 		guiButtonType = {
 			name = "diplomessageicon_button"
-			position = { x = -281 y = 17 }
+			position = { x = 14 y = -26 }
 			quadTextureSprite ="GFX_diplo_message_icons"	
 			tooltip = ""
 			tooltipText =""
@@ -97,7 +97,7 @@ guiTypes = {
 		
 		instantTextBoxType = {
 			name = "flag"
-			position = { x = -277 y =41 }
+			position = { x = 18 y =-2 }
 			format = centre
 			textureFile = ""
 
@@ -114,7 +114,7 @@ guiTypes = {
 		iconType = {
 				name ="messageicon_bg_overlay"
 				spriteType = "GFX_messageicon_bg_overlay"
-				position = { x= -273 y = 42 }
+				position = { x= 22 y = -1 }
 				Orientation = "UPPER_LEFT"
 		}
 	}

--- a/CTR/interface/topbar.gui
+++ b/CTR/interface/topbar.gui
@@ -1157,8 +1157,8 @@ guiTypes = {
 			position = { x = 204 y = 106 }
 			font = "vic_18_black"
 			borderSize = {x = 0 y = 0}
-			maxWidth = 300
-			maxHeight = 32	
+			maxWidth = 200
+			maxHeight = 20	
 			format = left
 		}
 


### PR DESCRIPTION
For some reason they just don't always work out, regardless of the
bounding boxes.

This reverts commit 1bec6eb9c578cc65d4c0a3e26790b0b5793f2013.