### PR TITLE
Break up swiss cultures further

### DIFF
--- a/CTR/common/cultures.txt
+++ b/CTR/common/cultures.txt
@@ -176,6 +176,20 @@ pan_swiss = {
 		"von Donatz" "von Salis-Soglio" "von Steiger" "von Tavel" Wille Celio Cotti Fogliardi Motta Zeni
 		Ador Calonder Chaudet Comtesse "de Prangins" Dufour Fornerod Guisan Ruchet Ruchonnet }
 	}
+	romansh = { 
+		color = { 120 140 110 }
+		first_names = { Alessandro Alfonso Ambrogio Amedeo Andrea Angelo Antonio Benito Camillo Carlo
+		Cesare Costanzo Davide Enrico Ettore Fabrizio Faustino Federico Felice Ferdinando
+		Fiorenzo Francesco Gaetano Gennaro Girolamo Giulio Giuseppe Guglielmo Innocenzo Leopoldo
+		Luigi Marco Massimo Matteo Nicola Oreste Paolo Pasquale Pietro Prospero
+		Raffaele Roberto Ruggiero Silvio Simone Tancredi Ugo Umberto Vincenzo Vittorio }
+		
+		last_names = { Acton Albricci Badoglio Baldissera Baratieri Bava-Beccaris Cadorna Cagni Canevaro Capello
+		Caviglia Ceccherini Cialdini Cusani d'Absburgo-Toscana d'Austria-Este Dezza "di Borbone di Parma" "di Robilant" "di Savoia"
+		"di Savoia-Aosta" Emo Fanti Fara Filomarino Garibaldi Giardino Govone "La Màrmora" Mambretti 
+		Menabrea Orengo "Pacoret de Saint Bon" Pallavicino Pecori-Giraldi "Pellion di Persano" Pelloux Perruchetti Pianelli Porro
+		Presbitero Ramorino Ricotti-Magnani Sacchi Saletta Sanna Solari "Thaon di Revel" Vaccari Zupelli }
+	}
 }
 	
 scandinavian = {

--- a/CTR/common/cultures.txt
+++ b/CTR/common/cultures.txt
@@ -176,62 +176,6 @@ pan_swiss = {
 		"von Donatz" "von Salis-Soglio" "von Steiger" "von Tavel" Wille Celio Cotti Fogliardi Motta Zeni
 		Ador Calonder Chaudet Comtesse "de Prangins" Dufour Fornerod Guisan Ruchet Ruchonnet }
 	}
-	swiss_french = { 
-		color = {40 40 190}
-		first_names = { Achille Adolphe Adrien Aimable Alphonse Amédée Antoine Armand August Augustin
-		Charles Daniel Denis Édouard Elie Éttiene Eugène Félicien Félix Fernand
-		François Frédéric Georges Guillaume Gustave Henri Hubert Hugo Jacques Jean
-		Joseph Jules Julien Lazare Léopold Leroy Louis Lucien Matthieu Michel
-		Napoléon Nicolas Patrice Paul Philippe Pierre Robert Thibaut Thierry Thomas }
-		
-		last_names = { Anthoine "Baraguey d'Hilliers" Bazaine Billot Bonaparte Bosquet "Boué de Lapeyrère" Bouët-Willaumez Boulanger Bourbaki
-		Bugeaud Caillard Canrobert Courbet Cousin-Mountauban Davout "de Bourbon" "de Castellane" "de Castelnau" "de Gaulle" 
-		"de Langle de Cary" "de MacMahon" "de Montaignac" "de Saint Arnaud" d'Orleans Dubail Dubois Duchêne Dupetit-Thouars Exelmans
-		Foch Forey "Franchet d'Espèrey" Gallieni Gouraud Guillaumat Hamelin Harispe Hoche Humbert
-		Jaurès Joffre Lebouef Lyautey Murat "Ney d'Elchingen" Nivelle Péllissier Petain Vaillant }
-	}	
-	swiss_german = {
-		color = { 150 110 110 }
-		first_names = { Adolf Albrecht Alexander Alfons Alois Anton Arthur Bernhard Christian
-		Edmund Eduard Engelbert Ernst Erwin Ferdinand Franz Friedrich Gebhard Gerhard Gottfried
-		Günther Gustav Heinrich Hermann Horst Jakob Joachim Johann Joseph
-		Julius Karl Konrad Kurt Leonhard Leopold Lorenz Lothar Ludwig Maximilian
-		Michael Otto Reinhold Rudolf Stefan Theodor Viktor Walter Werner Wilhelm }
-		
-		last_names = { Beck-Rzikowsky Blos Dankl Eisner Geiss Goering Hainisch Haus Held Hellpach
-		Hoffmann Hummel Köhler Mergenthaler Miklas Remmele Schmitt Schobber Seitz Steeb
-		Stolzer Trunk "von Baden" "von Benedek" "von Böhm-Ermolli" "von Brudermann" "von Clam-Gallas" "von der Tann" "von Dietrich" "von Gablenz"
-		"von Grünne" "von Habsburg" "von Hartmann" "von Haynau" "von Hess" "von Hohenhausen" "d'Aspre von Hoobreuk" "von Hortstein" "von Hötzendorf" "von Kirbach"
-		"von Kobratin" "von Schönburg" "von Tegetthoff" "von Uchatius" "von Wittelsbach" "von Württemberg" "von Zahringen" Wagner Wittmann "zu Hohenlohe" }
-	}
-	swiss_italian = { 
-		color = { 150 220 170 }
-		first_names = { Alessandro Alfonso Ambrogio Amedeo Andrea Angelo Antonio Benito Camillo Carlo
-		Cesare Costanzo Davide Enrico Ettore Fabrizio Faustino Federico Felice Ferdinando
-		Fiorenzo Francesco Gaetano Gennaro Girolamo Giulio Giuseppe Guglielmo Innocenzo Leopoldo
-		Luigi Marco Massimo Matteo Nicola Oreste Paolo Pasquale Pietro Prospero
-		Raffaele Roberto Ruggiero Silvio Simone Tancredi Ugo Umberto Vincenzo Vittorio }
-		
-		last_names = { Acton Albricci Badoglio Baldissera Baratieri Bava-Beccaris Cadorna Cagni Canevaro Capello
-		Caviglia Ceccherini Cialdini Cusani d'Absburgo-Toscana d'Austria-Este Dezza "di Borbone di Parma" "di Robilant" "di Savoia"
-		"di Savoia-Aosta" Emo Fanti Fara Filomarino Garibaldi Giardino Govone "La Màrmora" Mambretti 
-		Menabrea Orengo "Pacoret de Saint Bon" Pallavicino Pecori-Giraldi "Pellion di Persano" Pelloux Perruchetti Pianelli Porro
-		Presbitero Ramorino Ricotti-Magnani Sacchi Saletta Sanna Solari "Thaon di Revel" Vaccari Zupelli }
-	}
-	romansh = { 
-		color = { 120 140 110 }
-		first_names = { Alessandro Alfonso Ambrogio Amedeo Andrea Angelo Antonio Benito Camillo Carlo
-		Cesare Costanzo Davide Enrico Ettore Fabrizio Faustino Federico Felice Ferdinando
-		Fiorenzo Francesco Gaetano Gennaro Girolamo Giulio Giuseppe Guglielmo Innocenzo Leopoldo
-		Luigi Marco Massimo Matteo Nicola Oreste Paolo Pasquale Pietro Prospero
-		Raffaele Roberto Ruggiero Silvio Simone Tancredi Ugo Umberto Vincenzo Vittorio }
-		
-		last_names = { Acton Albricci Badoglio Baldissera Baratieri Bava-Beccaris Cadorna Cagni Canevaro Capello
-		Caviglia Ceccherini Cialdini Cusani d'Absburgo-Toscana d'Austria-Este Dezza "di Borbone di Parma" "di Robilant" "di Savoia"
-		"di Savoia-Aosta" Emo Fanti Fara Filomarino Garibaldi Giardino Govone "La Màrmora" Mambretti 
-		Menabrea Orengo "Pacoret de Saint Bon" Pallavicino Pecori-Giraldi "Pellion di Persano" Pelloux Perruchetti Pianelli Porro
-		Presbitero Ramorino Ricotti-Magnani Sacchi Saletta Sanna Solari "Thaon di Revel" Vaccari Zupelli }
-	}
 }
 	
 scandinavian = {

--- a/CTR/decisions/Setup.txt
+++ b/CTR/decisions/Setup.txt
@@ -1314,9 +1314,9 @@ political_decisions = {
 		effect = {
 			any_pop = { limit = { culture = ashkenazi } literacy = 0.70 }
 			any_pop = { limit = { culture = romansh } literacy = 0.70 }
-			any_pop = { limit = { culture = swiss_german } literacy = 0.70 }
-			any_pop = { limit = { culture = swiss_french } literacy = 0.70 }
-			any_pop = { limit = { culture = swiss_italian } literacy = 0.70 }
+			any_pop = { limit = { culture = south_german } literacy = 0.70 }
+			any_pop = { limit = { culture = french } literacy = 0.70 }
+			any_pop = { limit = { culture = north_italian } literacy = 0.70 }
 		}
 	}
 	

--- a/CTR/history/countries/NCT - Neuchatel.txt
+++ b/CTR/history/countries/NCT - Neuchatel.txt
@@ -1,9 +1,9 @@
 capital = 608
 primary_culture = swiss
-accepted_culture = south_german
-accepted_culture = french
-accepted_culture = north_italian
-accepted_culture = romansh
+culture = south_german
+culture = french
+culture = north_italian
+culture = romansh
 religion = protestant
 government = hms_government
 plurality = 25.0

--- a/CTR/history/countries/NCT - Neuchatel.txt
+++ b/CTR/history/countries/NCT - Neuchatel.txt
@@ -1,6 +1,6 @@
 capital = 608
 primary_culture = swiss
-accepted_culture = german
+accepted_culture = south_german
 accepted_culture = french
 accepted_culture = north_italian
 accepted_culture = romansh

--- a/CTR/history/countries/NCT - Neuchatel.txt
+++ b/CTR/history/countries/NCT - Neuchatel.txt
@@ -1,8 +1,9 @@
 capital = 608
 primary_culture = swiss
-accepted_culture = swiss_german
-accepted_culture = swiss_french
-accepted_culture = swiss_italian
+accepted_culture = german
+accepted_culture = french
+accepted_culture = north_italian
+accepted_culture = romansh
 religion = protestant
 government = hms_government
 plurality = 25.0

--- a/CTR/history/countries/SWI - Switzerland.txt
+++ b/CTR/history/countries/SWI - Switzerland.txt
@@ -1,9 +1,9 @@
 capital = 605
 primary_culture = swiss
-accepted_culture = south_german
-accepted_culture = french
-accepted_culture = north_italian
-accepted_culture = romansh
+culture = south_german
+culture = french
+culture = north_italian
+culture = romansh
 religion = protestant
 government = democracy
 plurality = 25.0

--- a/CTR/history/countries/SWI - Switzerland.txt
+++ b/CTR/history/countries/SWI - Switzerland.txt
@@ -1,9 +1,9 @@
 capital = 605
 primary_culture = swiss
-accepted_culture = swiss_german
-accepted_culture = swiss_french
-accepted_culture = swiss_italian
-accepted_culture = romansch
+accepted_culture = south_german
+accepted_culture = french
+accepted_culture = north_italian
+accepted_culture = romansh
 religion = protestant
 government = democracy
 plurality = 25.0

--- a/CTR/history/pops/1836.1.1/Switzerland.txt
+++ b/CTR/history/pops/1836.1.1/Switzerland.txt
@@ -2,37 +2,37 @@
 #Zurich (560000/140000 POPS)
 603 = {
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 450
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 1300
 	}
 
 	capitalists = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 100
 	}
 
 	clerks = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 60
 	}
 
 	craftsmen = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 21200
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 1150
 	}
@@ -44,55 +44,55 @@
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 67790
 	}
 
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 250
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 500
 	}
 
 	clerks = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 30
 	}
 
 	craftsmen = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 600
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 1750
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 48920
 	}
@@ -112,31 +112,31 @@
 #Basel (272000/68000 POPS)
 604 = {
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 75
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 135
 	}
 
 	clerks = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 35
 	}
 
 	craftsmen = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 375
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 1100
 	}
@@ -148,115 +148,115 @@
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 18370
 	}
 
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 75
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 125
 	}
 
 	clerks = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 30
 	}
 
 	craftsmen = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 300
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 925
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 14500
 	}
 
 	aristocrats = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 75
 	}
 
 	clergymen = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 135
 	}
 
 	craftsmen = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 375
 	}
 
 	artisans = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 18370
 	}
 
 	aristocrats = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 75
 	}
 
 	clergymen = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 125
 	}
 
 	craftsmen = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 300
 	}
 
 	artisans = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 925
 	}
 
 	farmers = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 14500
 	}
@@ -276,61 +276,61 @@
 #Bern (352000/88000 POPS)
 605 = {
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 350
 	}
 
 	capitalists = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 100
 	}
 
 	officers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 350
 	}
 
 	bureaucrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 800
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 625
 	}
 
 	clerks = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 75
 	}
 
 	craftsmen = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 1500
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 4500
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 85500
 	}
@@ -344,31 +344,31 @@
 #Lucerne (204000/51000 POPS)
 606 = {
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 175
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 350
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 3500
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 37475
 	}
@@ -384,85 +384,85 @@
 #Geneva (316000/79000 POPS)
 607 = {
 	aristocrats = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 200
 	}
 
 	bureaucrats = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 120
 	}
 
 	officers = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 60
 	}
 
 	clergymen = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 300
 	}
 
 	artisans = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 4000
 	}
 
 	soldiers = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 40520
 	}
 
 	aristocrats = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 300
 	}
 
 	bureaucrats = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 80
 	}
 
 	officers = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 50
 	}
 
 	clergymen = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 350
 	}
 
 	artisans = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 3000
 	}
 
 	soldiers = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 34430
 	}
@@ -487,31 +487,31 @@
 		size = 100
 	}
 	aristocrats = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 50
 	}
 
 	clergymen = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 125
 	}
 
 	artisans = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 3000
 	}
 
 	soldiers = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 150
 	}
 
 	farmers = {
-		culture = swiss_french
+		culture = french
 		religion = protestant
 		size = 17125
 	}
@@ -525,49 +525,49 @@
 #Sitten (72000/18000) POPS
 609 = {
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 150
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 90
 	}
 
 	clergymen = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 90
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 550
 	}
 
 	artisans = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 550
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_french
+		culture = french
 		religion = catholic
 		size = 11085
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 11085
 	}
@@ -583,43 +583,43 @@
 #Lugano (108000/27000 POPS)
 2568 = {
 	aristocrats = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 250
 	}
 
 	bureaucrats = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 100
 	}
 
 	officers = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 50
 	}
 
 	clergymen = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 275
 	}
 
 	artisans = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 1250
 	}
 
 	soldiers = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 1100
 	}
 
 	farmers = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 30575
 	}
@@ -651,7 +651,7 @@
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = catholic
 		size = 1100
 	}
@@ -663,37 +663,37 @@
 	}
 
 	farmers = {
-		culture = swiss_italian
+		culture = north_italian
 		religion = catholic
 		size = 2300
 	}
 
 	aristocrats = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 50
 	}
 
 	clergymen = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 50
 	}
 
 	artisans = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 350
 	}
 
 	soldiers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 75
 	}
 
 	farmers = {
-		culture = swiss_german
+		culture = south_german
 		religion = protestant
 		size = 6375
 	}


### PR DESCRIPTION
Get rid of the oddly specific pan-swiss cultures like swiss- italian, french, and german, and turn them into north italian, french, and south german respectively. Romansh can stay though.